### PR TITLE
Removed the collapse('reset') as it does not exist and caused issue #2

### DIFF
--- a/tabcordion.js
+++ b/tabcordion.js
@@ -201,9 +201,7 @@
         parent: this.$el.find('> ul'),
         toggle: false
       });
-      if (switchToTab) {
-        $content.collapse('reset');
-      } else {
+      if (!switchToTab) {
         $content.height(isActive ? 'auto' : 0);
         $content.collapse();
       }


### PR DESCRIPTION
After looking into this I noticed you called collapse('reset') but according to documentation there are only three functions possibles:

    .collapse('toggle')
    Toggles a collapsible element to shown or hidden.

    .collapse('show')
    Shows a collapsible element.

    .collapse('hide')
    Hides a collapsible element.

I removed the line with the error and all works fine on my side.